### PR TITLE
[feat] 로그인 처리 및 토큰 생성

### DIFF
--- a/src/main/java/com/me/wodada/auth/GeneratedToken.java
+++ b/src/main/java/com/me/wodada/auth/GeneratedToken.java
@@ -1,0 +1,15 @@
+package com.me.wodada.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@ToString
+public class GeneratedToken {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/me/wodada/auth/MainController.java
+++ b/src/main/java/com/me/wodada/auth/MainController.java
@@ -1,0 +1,26 @@
+package com.me.wodada.common;
+
+import com.me.wodada.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MainController {
+
+    @GetMapping("/")
+    public String main(){
+        return "main";
+    }
+
+    @GetMapping("/test")
+    public String test(@AuthenticationPrincipal Member member){
+        return "인증완료";
+    }
+
+}

--- a/src/main/java/com/me/wodada/auth/controller/AuthController.java
+++ b/src/main/java/com/me/wodada/auth/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.me.wodada.auth.controller;
+
+import com.me.wodada.auth.GeneratedToken;
+import com.me.wodada.auth.dto.AuthRequest;
+import com.me.wodada.auth.refreshToken.RefreshTokenService;
+import com.me.wodada.auth.service.AuthService;
+import com.me.wodada.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final RefreshTokenService refreshTokenService;
+    private final AuthService authService;
+
+    @PostMapping("/auth/token")
+    public ResponseEntity<GeneratedToken> generateToken(@RequestBody @Valid AuthRequest authRequest,
+                                                        HttpServletResponse response) throws IOException {
+        GeneratedToken generatedToken = authService.generateToken(response, authRequest);
+
+        return ResponseEntity.ok(generatedToken);
+    }
+
+    @PostMapping("/token/refresh")
+    public void refresh(HttpServletRequest request){
+        log.info("토큰 재발급");
+    }
+
+}

--- a/src/main/java/com/me/wodada/auth/dto/AuthRequest.java
+++ b/src/main/java/com/me/wodada/auth/dto/AuthRequest.java
@@ -1,0 +1,48 @@
+package com.me.wodada.auth.dto;
+
+import com.me.wodada.member.domain.Gender;
+import com.me.wodada.member.domain.Member;
+import com.me.wodada.member.domain.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class AuthRequest {
+    private String email;
+    private String nickname;
+    private String ageRange;
+    private String gender;
+    private String provider;
+
+    @Builder
+    public AuthRequest(String email, String nickname, String ageRange, String gender, String provider) {
+        this.email = email;
+        this.nickname = nickname;
+        this.ageRange = ageRange;
+        this.gender = gender;
+        this.provider = provider;
+    }
+
+    public static Member toEntity(AuthRequest request){
+        return Member.builder()
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .role(Role.GUEST)
+                .gender(toChangeGender(request.gender))
+                .ageRange(toChangeAge(request.getAgeRange()))
+                .provider(request.getProvider())
+                .build();
+    }
+
+    private static Gender toChangeGender(String genderStr) {
+        return genderStr.toUpperCase().substring(0, 1).equals("F") ? Gender.FEMALE :  Gender.MALE;
+    }
+
+    private static String toChangeAge(String ageRange) {
+        return ageRange.substring(0, 1) + "0대";
+    }
+}

--- a/src/main/java/com/me/wodada/auth/refreshToken/RefreshToken.java
+++ b/src/main/java/com/me/wodada/auth/refreshToken/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.me.wodada.auth.refreshToken;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class RefreshToken {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "refreshtoken_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @Builder
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateRefreshToken(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+    }
+}

--- a/src/main/java/com/me/wodada/auth/refreshToken/RefreshTokenRepository.java
+++ b/src/main/java/com/me/wodada/auth/refreshToken/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.me.wodada.auth.refreshToken;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+}

--- a/src/main/java/com/me/wodada/auth/refreshToken/RefreshTokenService.java
+++ b/src/main/java/com/me/wodada/auth/refreshToken/RefreshTokenService.java
@@ -1,0 +1,36 @@
+package com.me.wodada.auth.refreshToken;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void save(Long userId, String refreshToken, String email){
+        RefreshToken token = RefreshToken.builder()
+                .userId(userId)
+                .refreshToken(refreshToken)
+                .build();
+
+        refreshTokenRepository.save(token);
+    }
+
+    @Transactional
+    public void remove(Long userId){
+        RefreshToken token = refreshTokenRepository.findByUserId(userId)
+                .orElseThrow(RuntimeException::new);
+
+        refreshTokenRepository.delete(token);
+    }
+
+    public RefreshToken findRefreshToken(Long memberId){
+        return refreshTokenRepository.findByUserId(memberId)
+                .orElseThrow(RuntimeException::new);
+    }
+}

--- a/src/main/java/com/me/wodada/auth/service/AuthService.java
+++ b/src/main/java/com/me/wodada/auth/service/AuthService.java
@@ -1,0 +1,92 @@
+package com.me.wodada.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.me.wodada.auth.GeneratedToken;
+import com.me.wodada.auth.dto.AuthRequest;
+import com.me.wodada.auth.jwt.service.JwtService;
+import com.me.wodada.auth.refreshToken.RefreshToken;
+import com.me.wodada.auth.refreshToken.RefreshTokenService;
+import com.me.wodada.member.domain.Member;
+import com.me.wodada.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+    @Value("${jwt.access.expiration}")
+    private String accessTokenExpiration;
+
+    @Transactional
+    public GeneratedToken generateToken(HttpServletResponse response, AuthRequest authRequest) throws IOException {
+        Member member = memberRepository.findByEmailAndProvider(authRequest.getEmail(), authRequest.getProvider())
+                .orElse(null);
+
+        if (member == null){
+            // member 저장
+            Member newMember = AuthRequest.toEntity(authRequest);
+            Member savedMember = memberRepository.save(newMember);
+
+            // TODO : GUEST면 추가 정보 입력하도록 이동 가능
+            String accessToken = jwtService.createAccessToken(savedMember.getEmail(), savedMember.getRole().getKey()); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
+            String refreshToken = jwtService.createRefreshToken(); // JwtService의 createRefreshToken을 사용하여 RefreshToken 발급
+
+            response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+
+            // refreshtoken 저장
+            refreshTokenService.save(savedMember.getId(), refreshToken, savedMember.getEmail());
+            jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken); // 응답 헤더에 AccessToken 실어서 응답
+
+            GeneratedToken generatedToken = getGeneratedToken(response, accessToken, refreshToken);
+
+            log.info("1. 로그인에 성공하였습니다. 이메일 : {}", savedMember.getEmail());
+            log.info("1. 로그인에 성공하였습니다. AccessToken : {}", accessToken);
+            log.info("1. 로그인에 성공하였습니다. refreshToken : {}", refreshToken);
+            log.info("1. 발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+
+            return generatedToken;
+        }else{
+            GeneratedToken generatedToken = loginSuccess(response, member);
+            return generatedToken;
+        }
+    }
+
+    // TODO : RefreshToken 유/무에 따라 다르게 처리해보기
+    private GeneratedToken loginSuccess(HttpServletResponse response, Member member) throws IOException {
+        String accessToken = jwtService.createAccessToken(member.getEmail(), member.getRole().getKey());
+        RefreshToken refreshToken = refreshTokenService.findRefreshToken(member.getId());
+        String reIssuedRefreshToken = jwtService.createRefreshToken();
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + reIssuedRefreshToken);
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, reIssuedRefreshToken);
+        jwtService.updateRefreshToken(refreshToken.getRefreshToken(), reIssuedRefreshToken);
+
+        GeneratedToken generatedToken = getGeneratedToken(response, accessToken, reIssuedRefreshToken);
+
+        log.info("로그인에 성공하였습니다. 이메일 : {}", member.getEmail());
+        log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
+        log.info("로그인에 성공하였습니다. refreshToken : {}", reIssuedRefreshToken);
+        log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+
+        return generatedToken;
+    }
+
+    private GeneratedToken getGeneratedToken(HttpServletResponse response, String accessToken, String refreshToken) throws IOException {
+        return GeneratedToken.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/me/wodada/config/SecurityConfig.java
+++ b/src/main/java/com/me/wodada/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package com.me.wodada.config;
+
+import com.me.wodada.auth.handler.LoginFailureHandler;
+import com.me.wodada.auth.handler.LoginSuccessHandler;
+import com.me.wodada.auth.jwt.filter.JwtAuthenticationProcessingFilter;
+import com.me.wodada.auth.jwt.filter.JwtExceptionFilter;
+import com.me.wodada.auth.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final LoginSuccessHandler loginSuccessHandler;
+    private final LoginFailureHandler loginFailureHandler;
+    private final JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
+    @Bean
+    public WebSecurityCustomizer customizer(){
+        return web -> web.ignoring()
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)throws Exception {
+        http
+                .httpBasic(basic -> basic.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(login -> login.disable())
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(STATELESS))
+                .authorizeHttpRequests(authorize ->
+                        authorize.antMatchers("/token/**").permitAll()
+                                .antMatchers("/auth/token").permitAll()
+                                .antMatchers("/h2-console/**").permitAll()
+                                .antMatchers("/test").authenticated()
+                                .antMatchers("/api/member/**").authenticated()
+                                .anyRequest().permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/"))
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .successHandler(loginSuccessHandler)
+                        .failureHandler(loginFailureHandler)
+                        .userInfoEndpoint().userService(customOAuth2UserService)
+                );
+
+        return http
+                .addFilterBefore(jwtAuthenticationProcessingFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationProcessingFilter.class)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용

client에서 받은 유저 정보를 사용해서 로그인 or 회원 가입 처리 해준다.
이후에 RefreshToken과 AccessToken을 발급 받아준다.

+) 앞서 만들었던 JWT filter들을 SecurityConfig를 통해 추가해준다

## 📎 관련 이슈

This closes #9 