### PR TITLE
[feat] 유저 정보 수정 기능 관련 수정 및 PostController, WebCofig 수정

### DIFF
--- a/src/main/java/com/me/wodada/config/WebConfig.java
+++ b/src/main/java/com/me/wodada/config/WebConfig.java
@@ -1,7 +1,6 @@
 package com.me.wodada.config;
 
 import com.me.wodada.common.PermissionInterceptor;
-import com.me.wodada.common.RoleInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -12,7 +11,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final PermissionInterceptor permissionInterceptor;
-    private final RoleInterceptor roleInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/com/me/wodada/member/domain/Member.java
+++ b/src/main/java/com/me/wodada/member/domain/Member.java
@@ -40,7 +40,7 @@ public class Member extends BaseEntity {
 
     private String ageRange;
 
-    private String address;
+    private String area;
 
     @Lob
     private String bio;
@@ -57,7 +57,7 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(Role role, String email, String nickname, String profileImageUrl,
-                  Gender gender,String ageRange, String address, String bio,
+                  Gender gender,String ageRange, String area, String bio,
                   String provider, Double rating) {
         this.role = role;
         this.email = email;
@@ -65,7 +65,7 @@ public class Member extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.gender = gender;
         this.ageRange = ageRange;
-        this.address = address;
+        this.area = area;
         this.bio = bio;
         this.provider = provider;
         this.rating = rating;
@@ -73,7 +73,7 @@ public class Member extends BaseEntity {
 
     public void updateProfile(MemberInfoUpdateReq request) {
         this.nickname = request.getNickname();
-        this.address = request.getAddress();
+        this.area = request.getArea();
         this.bio = request.getBio();
         this.role = Role.USER;
     }

--- a/src/main/java/com/me/wodada/member/dto/request/MemberInfoUpdateReq.java
+++ b/src/main/java/com/me/wodada/member/dto/request/MemberInfoUpdateReq.java
@@ -5,13 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.Lob;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,25 +17,17 @@ public class MemberInfoUpdateReq {
     @Length(min = 2, max = 25, message = "닉네임은 2~25글자로 입력해주세요.")
     private String nickname;
 
-    @NotBlank
-    private String gender;
-
-    @NotBlank
-    private String ageRange;
-
-    @NotBlank(message = "주소를 입력하세요")
-    private String address;
+    @NotBlank(message = "활동 지역을 입력하세요")
+    private String area;
 
     @Lob
     private String bio;
 
     @Builder
     public MemberInfoUpdateReq(String nickname, String gender,
-                               String ageRange, String address, String bio) {
+                               String ageRange, String area, String bio) {
         this.nickname = nickname;
-        this.gender = gender;
-        this.ageRange = ageRange;
-        this.address = address;
+        this.area = area;
         this.bio = bio;
     }
 }

--- a/src/main/java/com/me/wodada/member/dto/response/MemberInfoRes.java
+++ b/src/main/java/com/me/wodada/member/dto/response/MemberInfoRes.java
@@ -15,34 +15,38 @@ import java.util.List;
 public class MemberInfoRes {
     private String nickname;
     private String profileImageUrl;
+
+    private String bio;
     private Gender gender;
     private String ageRange;
-    private String address;
+    private String area;
     private Double rating;
 
-    private List<PetInfoRes> petInfoList = new ArrayList<>();
+    private List<PetInfoRes> petList = new ArrayList<>();
 
     @Builder
-    public MemberInfoRes(String nickname, String profileImageUrl, Gender gender,
-                         String ageRange, String address, Double rating, List<PetInfoRes> petInfoList) {
+    public MemberInfoRes(String nickname, String profileImageUrl, String bio, Gender gender,
+                         String ageRange, String area, Double rating, List<PetInfoRes> petList) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.bio = bio;
         this.gender = gender;
         this.ageRange = ageRange;
-        this.address = address;
+        this.area = area;
         this.rating = rating;
-        this.petInfoList = petInfoList;
+        this.petList = petList;
     }
 
     public static MemberInfoRes from(Member member, List<PetInfoRes> petInfoList){
         return MemberInfoRes.builder()
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
+                .bio(member.getBio())
                 .gender(member.getGender())
                 .ageRange(member.getAgeRange())
-                .address(member.getAddress())
+                .area(member.getArea())
                 .rating(member.getRating())
-                .petInfoList(petInfoList)
+                .petList(petInfoList)
                 .build();
     }
 }

--- a/src/main/java/com/me/wodada/post/controller/PostController.java
+++ b/src/main/java/com/me/wodada/post/controller/PostController.java
@@ -48,11 +48,11 @@ public class PostController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("/getAll/{board}")
+    @GetMapping("/getAll/{boardType}")
     public ResponseEntity<PostAllRes> getAll(@AuthenticationPrincipal Member member,
-                       @PathVariable String board,
+                       @PathVariable String boardType,
                        Pageable pageable){
-        PostAllRes response = postService.getAll(board, pageable);
+        PostAllRes response = postService.getAll(boardType, pageable);
         return ResponseEntity.ok().body(response);
     }
 


### PR DESCRIPTION
## ✨ 작업 내용

기존에 구현했던 사용자 정보 수정 부분에서 빠진 bio를 추가하고,
address로 사용자의 주소를 받았던 부분을 area로 수정해 사용자의 주 활동 구역을 저장해준다.

추가적으로 PostController에서 전체 조회 부분의 파라미터 이름 수정,
WebCofig 파일에서 RoleInterceptor 삭제 진행 완료

## 📎 관련 이슈

This closes #24 